### PR TITLE
Mandatory User-Defined Log File

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ import (
 
 Then perform a `go mod tidy` to download the package.
 
+Please ensure that the log file is properly specified; otherwise, no information will be printed to the console. In the event that the log file is not configured correctly, relevant error messages will be printed to the console.
+
+```go
+    ...
+    logging.SetLogFile("samplelog.log")
+    ...
+```
+
 ### Customizing the logging prefix/header
 
 CNI-log allows users to modify the logging prefix/header. The default prefix is in the following format:

--- a/logging.go
+++ b/logging.go
@@ -53,6 +53,7 @@ const (
 	defaultLogLevel        = InfoLevel
 	defaultTimestampFormat = time.RFC3339
 
+	logFileExistsMsg   = "cni-log: log file '%s' already exists\n"
 	logFileReqFailMsg  = "cni-log: filename is required\n"
 	logFileFailMsg     = "cni-log: failed to set log file '%s'\n"
 	setLevelFailMsg    = "cni-log: cannot set logging level to '%s'\n"
@@ -154,6 +155,11 @@ func SetLogFile(filename string) {
 	if fp == "" {
 		fmt.Fprint(os.Stderr, logFileReqFailMsg)
 		return
+	}
+
+	// logging file already exists
+	if _, err := os.Stat(fp); err == nil {
+		fmt.Fprintf(os.Stdout, logFileExistsMsg, filename)
 	}
 
 	if !isLogFileWritable(fp) {

--- a/logging.go
+++ b/logging.go
@@ -53,7 +53,7 @@ const (
 	defaultLogLevel        = InfoLevel
 	defaultTimestampFormat = time.RFC3339
 
-	logFileExistsMsg   = "cni-log: log file '%s' already exists\n"
+	logFileExistsMsg   = "cni-log: log file '%s' exists - logger appends if below max size, else timestamps and creates new file.\n"
 	logFileReqFailMsg  = "cni-log: filename is required\n"
 	logFileFailMsg     = "cni-log: failed to set log file '%s'\n"
 	setLevelFailMsg    = "cni-log: cannot set logging level to '%s'\n"
@@ -157,14 +157,14 @@ func SetLogFile(filename string) {
 		return
 	}
 
-	// logging file already exists
-	if _, err := os.Stat(fp); err == nil {
-		fmt.Fprintf(os.Stdout, logFileExistsMsg, filename)
-	}
-
 	if !isLogFileWritable(fp) {
 		fmt.Fprintf(os.Stderr, logFileFailMsg, filename)
 		return
+	}
+
+	// logging file already exists
+	if _, err := os.Stat(fp); err == nil {
+		fmt.Fprintf(os.Stderr, logFileExistsMsg, filename)
 	}
 
 	logger.Filename = filename

--- a/logging_test.go
+++ b/logging_test.go
@@ -302,18 +302,23 @@ var _ = Describe("CNI Logging Operations", func() {
 
 		When("logfile is not set and an error to standard output is thrown", Ordered, func() {
 
+			BeforeAll(func() {
+				_, err := os.Create(testLogFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			BeforeEach(func() {
 				SetLogLevel(StringToLevel("error"))
 			})
 
 			AfterAll(func() {
 				// Delete test log file after all tests have run
-				err := os.Remove(logFile)
+				err := os.Remove(testLogFile)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should not log messages", func() {
-				Expect(validateLogFile("error", logFile)).To(BeFalse())
+				Expect(validateLogFile("error", testLogFile)).To(BeFalse())
 			})
 		})
 
@@ -399,7 +404,7 @@ var _ = Describe("CNI Logging Operations", func() {
 		When("custom io.Writer is set", func() {
 			It("should log message to custom out", func() {
 				var out bytes.Buffer
-				SetLogFile(logFile)
+				SetLogFile(testLogFile)
 				SetOutput(&out)
 				Infof(infoMsg)
 				Expect(out.String()).To(ContainSubstring(infoMsg))

--- a/logging_test.go
+++ b/logging_test.go
@@ -112,6 +112,21 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
+
+		When("the log file already exists", func() {
+			It("a error is outputted to standard error", func() {
+				_, err := os.Create(testLogFile)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedLoggerOutput := fmt.Sprintf(logFileExistsMsg, testLogFile)
+				loggerOutput := captureStdErrStr(SetLogFile, testLogFile)
+
+				Expect(loggerOutput).To(Equal(expectedLoggerOutput))
+
+				err = os.Remove(testLogFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 
 	Context("Converting strings to Levels", func() {


### PR DESCRIPTION
This pull request addresses an issue, where a default log file was automatically created, even if it remained unused. Therefore, the default log file is removed. This now means that users of this library will be required to use their own log file before executing any logging functions.

#### Key changes in this pull request include:

1. **Removed Default Log File**: The `init()` function in `logging.go` no longer sets a default log file.
2. **Enhanced `SetLogFile()`**: Error handling has been introduced to prevent users from setting an empty filename. If an empty filename is provided, a failure message will be directed to `os.Stderr`.
3. **Updated `printf()`**: Added a check to confirm whether a log file has been set before writing logs. **Therefore, no logs will be written and a error message will be logged to standard output.** 
4. **Refined Unit Tests**: Adjusted unit tests in `logging_test.go` to reflect these changes by removing tests that depended on the default log file and adding tests for the empty filename scenario.
5. **Updated user instructions**: Updated the instructions in the readme file to reflect these changes.