### PR TITLE
Series of improvements to the logger

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,30 @@
+name: unit-tests
+on: [push, pull_request]
+jobs:
+  lint:
+   runs-on: ubuntu-latest
+   name: lint
+   steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version.
+          version: v1.52.2
+  unit-test:
+   runs-on: ubuntu-latest
+   name: unit-test
+   steps:
+     - name: Set up Go
+       uses: actions/setup-go@v3
+       with:
+         go-version: 1.18.x
+     - name: Check out code into the Go module directory
+       uses: actions/checkout@v3
+     - name: Run test
+       run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,119 @@
+run:
+  timeout: 3m
+  skip-dirs:
+    - vendor/
+    - .github/
+    - deployments/
+    - docs/
+    - images/
+
+linters-settings:
+  depguard:
+    list-type: blacklist
+    packages:
+      # logging is allowed only by logutils.Log, logrus
+      # is allowed to use only in logutils package
+      - github.com/sirupsen/logrus
+    packages-with-error-message:
+      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+      - unnamedResult
+    settings:
+      hugeParam:
+        sizeThreshold: 512
+      rangeValCopy:
+        sizeThreshold: 512
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/k8snetworkplumbingwg/sriov-network-device-plugin
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+        ignored-functions: os.*
+  lll:
+    line-length: 140
+  misspell:
+    locale: US
+  prealloc:
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+      #- gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+      #- govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - rowserrcheck
+      #- scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gomnd
+        - gosec
+        - dupl
+        - lll
+        - stylecheck
+        - goconst

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: test
+test: ## Run unit tests
+	go test -v .
+
+GOLANGCILINT = $(GOBIN)/golangci-lint
+$(GOLANGCILINT): | $(BASE) ; $(info  Installing golangci-lint...)
+	$Q go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+
+.PHONY: lint
+lint: | $(BASE) $(GOLANGCILINT) ; $(info  Running golangci-lint...) @ ## Run golint on all source files
+	$Q $(GOLANGCILINT) run ./...
+
+.PHONY: test-coverage
+test-coverage: ## Get test coverage
+	go test -count 1 -coverprofile=coverage.out  .
+	go tool cover -html=coverage.out
+
+.PHONY: help
+help: ; @ ## Display this help message
+	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -200,14 +200,6 @@ func (l Level) String() string
 
 Returns the string representation of a log level
 
-##### SetLogStderr
-
-```go
-func SetLogStderr(enable bool)
-```
-
-This function allows you to enable/disable logging to standard error.
-
 ##### SetLogOptions
 
 ```go
@@ -222,7 +214,19 @@ Configures the lumberjack object based on the lumberjack configuration data set 
 func SetLogFile(filename string)
 ```
 
-Configures where logs will be written to. If an empty/invalid filepath (e.g. insufficient permissions), or a symbolic link is passed into the function, the default log filepath is used.
+Configures where logs will be written to. If an empty filepath is used, disable logging to file.
+No change will occur if an invalid filepath (e.g. insufficient permissions) or a symbolic link is passed into the
+function.
+
+##### SetLogStderr
+
+```go
+func SetLogStderr(enable bool)
+```
+
+This function allows you to enable/disable logging to standard error.
+
+> **NOTE:** For logging, a valid log file must be set or logging to stderr must be enabled.
 
 ##### SetOutput
 
@@ -250,6 +254,9 @@ This function allows you to return to the default logging prefix.
 
 #### Logging functions
 
+The logger comes with 2 sets of logging functions.
+
+`Printf` style functions:
 ```go
 // Errorf prints logging if logging level >= error
 func Errorf(format string, a ...interface{}) error 
@@ -267,12 +274,34 @@ func Debugf(format string, a ...interface{})
 func Verbosef(format string, a ...interface{})
 ```
 
+Structured (crio logging style) functions:
+```go
+// PanicStructured provides structured logging for log level >= panic.
+func PanicStructured(msg string, args ...interface{})
+
+// ErrorStructured provides structured logging for log level >= error.
+func ErrorStructured(msg string, args ...interface{}) error
+
+// WarningStructured provides structured logging for log level >= warning.
+func WarningStructured(msg string, args ...interface{})
+
+// InfoStructured provides structured logging for log level >= info.
+func InfoStructured(msg string, args ...interface{})
+
+// DebugStructured provides structured logging for log level >= debug.
+func DebugStructured(msg string, args ...interface{})
+
+// VerboseStructured provides structured logging for log level >= verbose.
+func VerboseStructured(msg string, args ...interface{})
+```
+
 ### Default values
 
 | Variable | Default Value |
 | ---     | ---           |
 | logLevel | info |
-| Logger.Filename | ``/var/log/cni-log.log`` |
+| logToStderr | true |
+| Logger.Filename | "" |
 | LogOptions.MaxSize | 100 |
 | LogOptions.MaxAge | 5 |
 | LogOptions.MaxBackups | 5 |

--- a/logging.go
+++ b/logging.go
@@ -257,7 +257,7 @@ func Verbosef(format string, a ...interface{}) {
 	printf(VerboseLevel, format, a...)
 }
 
-func doWrite(writer io.Writer, level Level, format string, a ...interface{}) {
+func doWritef(writer io.Writer, level Level, format string, a ...interface{}) {
 	fmt.Fprint(writer, prefixer.CreatePrefix(level))
 	fmt.Fprintf(writer, format, a...)
 	fmt.Fprintf(writer, "\n")
@@ -274,11 +274,11 @@ func printf(level Level, format string, a ...interface{}) {
 	}
 
 	if logToStderr {
-		doWrite(os.Stderr, level, format, a...)
+		doWritef(os.Stderr, level, format, a...)
 	}
 
 	if logWriter != nil {
-		doWrite(logWriter, level, format, a...)
+		doWritef(logWriter, level, format, a...)
 	}
 }
 

--- a/logging.go
+++ b/logging.go
@@ -51,7 +51,7 @@ const (
 
 const (
 	defaultLogLevel        = InfoLevel
-	defaultTimestampFormat = time.RFC3339
+	defaultTimestampFormat = time.RFC3339Nano
 
 	logFileReqFailMsg  = "cni-log: filename is required when logging to stderr is off - will not log anything\n"
 	logFileFailMsg     = "cni-log: failed to set log file '%s'\n"

--- a/logging.go
+++ b/logging.go
@@ -99,9 +99,17 @@ type LogOptions struct {
 }
 
 func init() {
-	logToStderr = true
-	logLevel = defaultLogLevel
+	initLogger()
+}
+
+func initLogger() {
 	logger = &lumberjack.Logger{}
+
+	// Set default options.
+	SetLogOptions(nil)
+	SetLogStderr(true)
+	SetLogFile("")
+	SetLogLevel(defaultLogLevel)
 
 	// Create the default prefixer
 	SetDefaultPrefixer()

--- a/logging.go
+++ b/logging.go
@@ -284,6 +284,8 @@ func printf(level Level, format string, a ...interface{}) {
 	}
 }
 
+// isLogFileWritable checks if the path can be written to. If the file does not exist yet, the entire path including
+// the file will be created.
 func isLogFileWritable(filename string) bool {
 	logFileDirs := filepath.Dir(filename)
 
@@ -297,9 +299,11 @@ func isLogFileWritable(filename string) bool {
 		}
 	}
 
-	if _, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644); err != nil {
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
 		return false
 	}
+	f.Close()
 
 	return true
 }

--- a/logging.go
+++ b/logging.go
@@ -46,7 +46,7 @@ const (
 	InfoLevel    Level = 4
 	DebugLevel   Level = 5
 	VerboseLevel Level = 6
-	maximumLevel Level = 7
+	maximumLevel Level = VerboseLevel
 )
 
 const (
@@ -330,5 +330,5 @@ func resolvePath(path string) string {
 }
 
 func validateLogLevel(level Level) bool {
-	return level > 0 && level < maximumLevel
+	return level > 0 && level <= maximumLevel
 }

--- a/logging.go
+++ b/logging.go
@@ -53,7 +53,6 @@ const (
 	defaultLogLevel        = InfoLevel
 	defaultTimestampFormat = time.RFC3339
 
-	logFileExistsMsg   = "cni-log: log file '%s' exists - logger appends if below max size, else timestamps and creates new file.\n"
 	logFileReqFailMsg  = "cni-log: filename is required\n"
 	logFileFailMsg     = "cni-log: failed to set log file '%s'\n"
 	setLevelFailMsg    = "cni-log: cannot set logging level to '%s'\n"
@@ -168,11 +167,6 @@ func SetLogFile(filename string) {
 	if !isLogFileWritable(fp) {
 		fmt.Fprintf(os.Stderr, logFileFailMsg, filename)
 		return
-	}
-
-	// logging file already exists
-	if _, err := os.Stat(fp); err == nil {
-		fmt.Fprintf(os.Stderr, logFileExistsMsg, filename)
 	}
 
 	logger.Filename = filename

--- a/logging.go
+++ b/logging.go
@@ -317,13 +317,13 @@ func SetOutput(out io.Writer) {
 func Panicf(format string, a ...interface{}) {
 	printf(PanicLevel, format, a...)
 	printf(PanicLevel, "========= Stack trace output ========")
-	printf(PanicLevel, "%+v", Errorf("CNI Panic"))
+	printf(PanicLevel, "%+v", string(debug.Stack()))
 	printf(PanicLevel, "========= Stack trace output end ========")
 }
 
 // PanicStructured provides structured logging for log level >= panic.
 func PanicStructured(msg string, args ...interface{}) {
-	stackTrace := strings.Replace(string(debug.Stack()), "\n", "\\n", -1)
+	stackTrace := string(debug.Stack())
 	args = append(args, "stacktrace", stackTrace)
 	m := structuredMessage(PanicLevel, msg, args...)
 	printWithPrefixf(PanicLevel, false, m)

--- a/logging_test.go
+++ b/logging_test.go
@@ -53,7 +53,7 @@ var _ = Describe("CNI Logging Operations", func() {
 		When("the log file name is empty", func() {
 			It("an error to standard output is thrown", func() {
 				err := captureStdErrStr(SetLogFile, "")
-				Expect(err).To(ContainSubstring(emptyStringFailMsg))
+				Expect(err).To(ContainSubstring(logFileReqFailMsg))
 			})
 		})
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -150,7 +150,7 @@ var _ = Describe("CNI Logging Operations", func() {
 	Context("Setting the log level", func() {
 		When("a valid log level argument is passed in", func() {
 			It("sets the appropriate log level", func() {
-				//by string
+				// by string
 				SetLogLevel(StringToLevel("debug"))
 				Expect(logLevel).To(Equal(DebugLevel))
 				SetLogLevel(StringToLevel("INFO"))
@@ -163,13 +163,13 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(logLevel).To(Equal(ErrorLevel))
 				SetLogLevel(StringToLevel("panic"))
 				Expect(logLevel).To(Equal(PanicLevel))
-				//by int
+				// by int
 				for i := 1; i <= 6; i++ {
 					l := Level(i)
 					SetLogLevel(l)
 					Expect(logLevel).To(Equal(l))
 				}
-				//by level
+				// by level
 				SetLogLevel(VerboseLevel)
 				Expect(logLevel).To(Equal(VerboseLevel))
 				SetLogLevel(WarningLevel)
@@ -514,8 +514,7 @@ var _ = Describe("CNI Logging Operations", func() {
 })
 
 // Checks if the logging prints out the custom prefix
-func validateLogFilePrefix(filename string, prefix string) bool {
-
+func validateLogFilePrefix(filename, prefix string) bool {
 	// Populate the log file
 	Infof(infoMsg)
 
@@ -530,8 +529,7 @@ func validateLogFilePrefix(filename string, prefix string) bool {
 }
 
 // Checks if the correct log messages are in the log file depending on the log level set
-func validateLogFile(logLevel string, filename string) bool {
-
+func validateLogFile(logLevel, filename string) bool {
 	logLevel = strings.ToLower(logLevel)
 	logFileCorrect := true
 
@@ -570,7 +568,7 @@ func validateLogFile(logLevel string, filename string) bool {
 func openPipes() (*os.File, *os.File, *os.File) {
 	origWriter := os.Stderr
 
-	pipeReader, pipeWriter, err := os.Pipe() // Initialise an IO pipe
+	pipeReader, pipeWriter, err := os.Pipe() // Initialize an IO pipe
 	if err != nil {
 		panic(err)
 	}
@@ -580,7 +578,7 @@ func openPipes() (*os.File, *os.File, *os.File) {
 	return pipeReader, pipeWriter, origWriter
 }
 
-func closePipes(reader *os.File, writer *os.File, orig *os.File) string {
+func closePipes(reader, writer, orig *os.File) string {
 	writer.Close()
 	os.Stderr = orig // Revert stderr to what it used to be
 
@@ -593,7 +591,7 @@ func closePipes(reader *os.File, writer *os.File, orig *os.File) string {
 	return buff.String()
 }
 
-func captureStdErrLogging(f func(string, string) bool, p1 string, p2 string) string {
+func captureStdErrLogging(f func(string, string) bool, p1, p2 string) string {
 	pipeWriter, pipeReader, origWriter := openPipes()
 	f(p1, p2)
 	return closePipes(pipeWriter, pipeReader, origWriter)

--- a/logging_test.go
+++ b/logging_test.go
@@ -53,7 +53,7 @@ var _ = Describe("CNI Logging Operations", func() {
 		When("the log file name is empty", func() {
 			It("an error to standard output is thrown", func() {
 				err := captureStdErrStr(SetLogFile, "")
-				Expect(err).To(ContainSubstring(logFileReqFailMsg))
+				Expect(err).To(ContainSubstring(emptyStringFailMsg))
 			})
 		})
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -112,21 +112,6 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-
-		When("the log file already exists", func() {
-			It("a error is outputted to standard error", func() {
-				_, err := os.Create(testLogFile)
-				Expect(err).ToNot(HaveOccurred())
-
-				expectedLoggerOutput := fmt.Sprintf(logFileExistsMsg, testLogFile)
-				loggerOutput := captureStdErrStr(SetLogFile, testLogFile)
-
-				Expect(loggerOutput).To(Equal(expectedLoggerOutput))
-
-				err = os.Remove(testLogFile)
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
 	})
 
 	Context("Converting strings to Levels", func() {


### PR DESCRIPTION
Series of improvements to the logger:

* Add Makefile with targets test, lint and test-coverage
* Initialize all logger configuration to sane defaults
* Set maximumLevel = VerboseLevel instead of explicit value
* Do not check if a log file already exists.
* Explicitly close file descriptor for isLogFileWritable
* Return and use error message from resolvePath
* Allow logging to stderr only
* Improve test suite
* Add structured logging
* Add unit tests for structured logging

Fixes #11
Fixes #12 