### PR TITLE
Remove Verbose logging level, return InvalidLevel from StringToLevel, replace level strings with constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ type customPrefix struct {
 func main() {
   // cni-log configuration
   logging.SetLogFile("samplelog.log")
-  logging.SetLogLevel(logging.VerboseLevel)
+  logging.SetLogLevel(logging.DebugLevel)
   logging.SetLogStderr(true)
 
   // Creating the custom prefix object
@@ -172,9 +172,8 @@ Sets the log level. The valid log levels are:
 | 3 | warning | WarningLevel |
 | 4 | info | InfoLevel |
 | 5 | debug | DebugLevel |
-| 6 | verbose | VerboseLevel |
 
-The log levels above are in ascending order of verbosity. For example, setting the log level to InfoLevel would mean "panic", "error", warning", and "info" messages will get logged while "debug", and "verbose" will not.
+The log levels above are in ascending order of verbosity. For example, setting the log level to InfoLevel would mean "panic", "error", warning", and "info" messages will get logged while "debug" will not.
 
 ##### GetLogLevel
 
@@ -269,9 +268,6 @@ func Infof(format string, a ...interface{})
 
 // Debugf prints logging if logging level >= debug
 func Debugf(format string, a ...interface{})
-
-// Verbosef prints logging if logging level >= verbose
-func Verbosef(format string, a ...interface{})
 ```
 
 Structured (crio logging style) functions:
@@ -290,9 +286,6 @@ func InfoStructured(msg string, args ...interface{})
 
 // DebugStructured provides structured logging for log level >= debug.
 func DebugStructured(msg string, args ...interface{})
-
-// VerboseStructured provides structured logging for log level >= verbose.
-func VerboseStructured(msg string, args ...interface{})
 ```
 
 ### Default values

--- a/logging.go
+++ b/logging.go
@@ -46,6 +46,12 @@ const (
 	InfoLevel    Level = 4
 	DebugLevel   Level = 5
 	maximumLevel Level = DebugLevel
+
+	panicStr   = "panic"
+	errorStr   = "error"
+	warningStr = "warning"
+	infoStr    = "info"
+	debugStr   = "debug"
 )
 
 const (
@@ -62,11 +68,11 @@ const (
 )
 
 var levelMap = map[string]Level{
-	"panic":   PanicLevel,
-	"error":   ErrorLevel,
-	"warning": WarningLevel,
-	"info":    InfoLevel,
-	"debug":   DebugLevel,
+	panicStr:   PanicLevel,
+	errorStr:   ErrorLevel,
+	warningStr: WarningLevel,
+	infoStr:    InfoLevel,
+	debugStr:   DebugLevel,
 }
 
 var logger *lumberjack.Logger
@@ -289,15 +295,15 @@ func SetLogStderr(enable bool) {
 func (l Level) String() string {
 	switch l {
 	case PanicLevel:
-		return "panic"
+		return panicStr
 	case WarningLevel:
-		return "warning"
+		return warningStr
 	case InfoLevel:
-		return "info"
+		return infoStr
 	case ErrorLevel:
-		return "error"
+		return errorStr
 	case DebugLevel:
-		return "debug"
+		return debugStr
 	default:
 		return "unknown"
 	}

--- a/logging.go
+++ b/logging.go
@@ -37,7 +37,6 @@ Common use of different level:
 "warning": Unusual event occurred (invalid input or system issue), but continuing
 "info":    Basic information, indication of major code paths
 "debug":   Additional information, indication of minor code branches
-"verbose": Output of larger variables in code and debug of low level functions
 */
 
 const (
@@ -46,8 +45,7 @@ const (
 	WarningLevel Level = 3
 	InfoLevel    Level = 4
 	DebugLevel   Level = 5
-	VerboseLevel Level = 6
-	maximumLevel Level = VerboseLevel
+	maximumLevel Level = DebugLevel
 )
 
 const (
@@ -69,7 +67,6 @@ var levelMap = map[string]Level{
 	"warning": WarningLevel,
 	"info":    InfoLevel,
 	"debug":   DebugLevel,
-	"verbose": VerboseLevel,
 }
 
 var logger *lumberjack.Logger
@@ -293,8 +290,6 @@ func (l Level) String() string {
 	switch l {
 	case PanicLevel:
 		return "panic"
-	case VerboseLevel:
-		return "verbose"
 	case WarningLevel:
 		return "warning"
 	case InfoLevel:
@@ -373,17 +368,6 @@ func Debugf(format string, a ...interface{}) {
 func DebugStructured(msg string, args ...interface{}) {
 	m := structuredMessage(DebugLevel, msg, args...)
 	printWithPrefixf(DebugLevel, false, m)
-}
-
-// Verbosef prints logging if logging level >= verbose
-func Verbosef(format string, a ...interface{}) {
-	printf(VerboseLevel, format, a...)
-}
-
-// VerboseStructured provides structured logging for log level >= verbose.
-func VerboseStructured(msg string, args ...interface{}) {
-	m := structuredMessage(VerboseLevel, msg, args...)
-	printWithPrefixf(VerboseLevel, false, m)
 }
 
 // structuredMessage takes msg and an even list of args and returns a structured message.

--- a/logging.go
+++ b/logging.go
@@ -387,7 +387,7 @@ func structuredMessage(loggingLevel Level, msg string, args ...interface{}) stri
 
 	var output []string
 	for i := 0; i < len(prefixArgs)-1; i += 2 {
-		output = append(output, fmt.Sprintf("%s=%q", prefixArgs[i], prefixArgs[i+1]))
+		output = append(output, fmt.Sprintf("%s=%q", argToString(prefixArgs[i]), argToString(prefixArgs[i+1])))
 	}
 
 	if len(args)%2 != 0 {
@@ -396,10 +396,15 @@ func structuredMessage(loggingLevel Level, msg string, args ...interface{}) stri
 	}
 
 	for i := 0; i < len(args)-1; i += 2 {
-		output = append(output, fmt.Sprintf("%s=%q", args[i], args[i+1]))
+		output = append(output, fmt.Sprintf("%s=%q", argToString(args[i]), argToString(args[i+1])))
 	}
 
 	return strings.Join(output, " ")
+}
+
+// argToString returns the string representation of the provided interface{}.
+func argToString(arg interface{}) string {
+	return fmt.Sprintf("%+v", arg)
 }
 
 // doWritef takes care of the low level writing to the output io.Writer.

--- a/logging.go
+++ b/logging.go
@@ -40,6 +40,7 @@ Common use of different level:
 */
 
 const (
+	InvalidLevel Level = -1
 	PanicLevel   Level = 1
 	ErrorLevel   Level = 2
 	WarningLevel Level = 3
@@ -52,6 +53,7 @@ const (
 	warningStr = "warning"
 	infoStr    = "info"
 	debugStr   = "debug"
+	invalidStr = "invalid"
 )
 
 const (
@@ -278,9 +280,7 @@ func StringToLevel(level string) Level {
 	if l, found := levelMap[strings.ToLower(level)]; found {
 		return l
 	}
-
-	fmt.Fprintf(os.Stderr, setLevelFailMsg, level)
-	return -1
+	return InvalidLevel
 }
 
 // SetLogStderr sets flag for logging stderr output
@@ -304,8 +304,10 @@ func (l Level) String() string {
 		return errorStr
 	case DebugLevel:
 		return debugStr
+	case InvalidLevel:
+		return invalidStr
 	default:
-		return "unknown"
+		return invalidStr
 	}
 }
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -578,11 +578,8 @@ var _ = Describe("CNI Log Level Operations", func() {
 			})
 
 			When("an invalid string is passed", func() {
-				It("returns -1", func() {
-					invalidLogLevel := "invalid"
-					expectedLoggerOutput := fmt.Sprintf(setLevelFailMsg, invalidLogLevel)
-					loggerOutput := captureStdErrStrLev(StringToLevel, invalidLogLevel)
-					Expect(loggerOutput).To(Equal(expectedLoggerOutput))
+				It("returns InvalidLevel (-1)", func() {
+					Expect(StringToLevel(invalidStr)).To(Equal(InvalidLevel))
 				})
 			})
 		})
@@ -696,12 +693,6 @@ func captureStdErr[T any](f func(T), p T) string {
 func captureStdErrEvent(f func(string, ...interface{}), s string, a ...interface{}) string { //nolint:unparam
 	pipeWriter, pipeReader, origWriter := openPipes()
 	f(s, a...)
-	return closePipes(pipeWriter, pipeReader, origWriter)
-}
-
-func captureStdErrStrLev(f func(string) Level, p string) string {
-	pipeWriter, pipeReader, origWriter := openPipes()
-	f(p)
 	return closePipes(pipeWriter, pipeReader, origWriter)
 }
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -265,7 +265,7 @@ var _ = Describe("CNI Logging Operations", func() {
 		When("log level is set to ERROR", Ordered, func() {
 			It("should print appropriate >= error messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("error"))
+				SetLogLevel(StringToLevel(errorStr))
 				SetLogStderr(false)
 
 				Panicf(panicMsg)
@@ -282,26 +282,26 @@ var _ = Describe("CNI Logging Operations", func() {
 
 			It("should print appropriate >= error structured messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("error"))
+				SetLogLevel(StringToLevel(errorStr))
 				SetLogStderr(false)
 
 				PanicStructured(panicMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="panic" msg=%q`, panicMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, panicStr, panicMsg))).To(BeTrue())
 				_ = ErrorStructured(errorMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="error" msg=%q`, errorMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, errorStr, errorMsg))).To(BeTrue())
 				WarningStructured(warningMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="warning" msg=%q`, warningMsg))).To(BeFalse())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, warningStr, warningMsg))).To(BeFalse())
 				InfoStructured(infoMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg))).To(BeFalse())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, infoStr, infoMsg))).To(BeFalse())
 				DebugStructured(debugMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="debug" msg=%q`, debugMsg))).To(BeFalse())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, debugStr, debugMsg))).To(BeFalse())
 			})
 		})
 
 		When("log level is set to INFO", func() {
 			It("should print appropriate >= info messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("info"))
+				SetLogLevel(StringToLevel(infoStr))
 				SetLogStderr(false)
 
 				Panicf(panicMsg)
@@ -318,26 +318,26 @@ var _ = Describe("CNI Logging Operations", func() {
 
 			It("should print appropriate >= info structured messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("info"))
+				SetLogLevel(StringToLevel(infoStr))
 				SetLogStderr(false)
 
 				PanicStructured(panicMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="panic" msg=%q`, panicMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, panicStr, panicMsg))).To(BeTrue())
 				_ = ErrorStructured(errorMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="error" msg=%q`, errorMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, errorStr, errorMsg))).To(BeTrue())
 				WarningStructured(warningMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="warning" msg=%q`, warningMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, warningStr, warningMsg))).To(BeTrue())
 				InfoStructured(infoMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, infoStr, infoMsg))).To(BeTrue())
 				DebugStructured(debugMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="debug" msg=%q`, debugMsg))).To(BeFalse())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, debugStr, debugMsg))).To(BeFalse())
 			})
 		})
 
 		When("log level is set to DEBUG and messages are logged", func() {
 			It("should print appropriate >= debug messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("debug"))
+				SetLogLevel(StringToLevel(debugStr))
 				SetLogStderr(false)
 
 				Panicf(panicMsg)
@@ -354,19 +354,19 @@ var _ = Describe("CNI Logging Operations", func() {
 
 			It("should print appropriate >= debug structured messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("debug"))
+				SetLogLevel(StringToLevel(debugStr))
 				SetLogStderr(false)
 
 				PanicStructured(panicMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="panic" msg=%q`, panicMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, panicStr, panicMsg))).To(BeTrue())
 				_ = ErrorStructured(errorMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="error" msg=%q`, errorMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, errorStr, errorMsg))).To(BeTrue())
 				WarningStructured(warningMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="warning" msg=%q`, warningMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, warningStr, warningMsg))).To(BeTrue())
 				InfoStructured(infoMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, infoStr, infoMsg))).To(BeTrue())
 				DebugStructured(debugMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="debug" msg=%q`, debugMsg))).To(BeTrue())
+				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level=%q msg=%q`, debugStr, debugMsg))).To(BeTrue())
 			})
 		})
 
@@ -478,7 +478,7 @@ var _ = Describe("CNI Logging Operations", func() {
 
 		When("a custom prefix is provided", func() {
 			BeforeEach(func() {
-				SetLogLevel(StringToLevel("debug"))
+				SetLogLevel(StringToLevel(debugStr))
 				SetPrefixer(&customPrefix{
 					prefixFormat: "[%s/%s] - %s: ",
 					currentFile:  "logging_test.go",
@@ -511,7 +511,7 @@ var _ = Describe("CNI Logging Operations", func() {
 
 		When("a custom structured prefix is not provided", func() {
 			It("uses the default prefix", func() {
-				expected := fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg)
+				expected := fmt.Sprintf(`time=".*" level=%q msg=%q`, infoStr, infoMsg)
 				errStr := captureStdErrEvent(InfoStructured, infoMsg)
 				Expect(errStr).To(MatchRegexp(expected))
 				Expect(logFileContainsRegex(logFile, expected)).To(BeTrue())
@@ -520,14 +520,14 @@ var _ = Describe("CNI Logging Operations", func() {
 
 		When("a custom structured prefix is provided", func() {
 			BeforeEach(func() {
-				SetLogLevel(StringToLevel("debug"))
+				SetLogLevel(StringToLevel(debugStr))
 				SetStructuredPrefixer(&customPrefix{
 					currentFile: "logging_test.go",
 				})
 			})
 
 			It("uses the custom structured prefix", func() {
-				expected := fmt.Sprintf(`custom-level="info" custom-file="logging_test.go" custom-message=%q`, infoMsg)
+				expected := fmt.Sprintf(`custom-level=%q custom-file="logging_test.go" custom-message=%q`, infoStr, infoMsg)
 				errStr := captureStdErrEvent(InfoStructured, infoMsg)
 				Expect(errStr).To(MatchRegexp(expected))
 				Expect(logFileContainsRegex(logFile, expected)).To(BeTrue())
@@ -536,7 +536,7 @@ var _ = Describe("CNI Logging Operations", func() {
 			It("uses the default structured prefix when explicitly requesting to do so", func() {
 				SetDefaultStructuredPrefixer()
 
-				expected := fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg)
+				expected := fmt.Sprintf(`time=".*" level=%q msg=%q`, infoStr, infoMsg)
 				errStr := captureStdErrEvent(InfoStructured, infoMsg)
 				Expect(errStr).To(MatchRegexp(expected))
 				Expect(logFileContainsRegex(logFile, expected)).To(BeTrue())
@@ -571,7 +571,7 @@ var _ = Describe("CNI Log Level Operations", func() {
 		Context("Converting strings to Levels", func() {
 			When("a valid string is passed", func() {
 				It("returns the correct level value", func() {
-					Expect(StringToLevel("warning")).To(Equal(WarningLevel))
+					Expect(StringToLevel(warningStr)).To(Equal(WarningLevel))
 					Expect(StringToLevel("ERROR")).To(Equal(ErrorLevel))
 					Expect(StringToLevel("dEbUg")).To(Equal(DebugLevel))
 				})
@@ -591,15 +591,15 @@ var _ = Describe("CNI Log Level Operations", func() {
 			When("a valid log level argument is passed in", func() {
 				It("sets the appropriate log level", func() {
 					// by string
-					SetLogLevel(StringToLevel("debug"))
+					SetLogLevel(StringToLevel(debugStr))
 					Expect(logLevel).To(Equal(DebugLevel))
-					SetLogLevel(StringToLevel("info"))
+					SetLogLevel(StringToLevel(infoStr))
 					Expect(logLevel).To(Equal(InfoLevel))
-					SetLogLevel(StringToLevel("warning"))
+					SetLogLevel(StringToLevel(warningStr))
 					Expect(logLevel).To(Equal(WarningLevel))
-					SetLogLevel(StringToLevel("error"))
+					SetLogLevel(StringToLevel(errorStr))
 					Expect(logLevel).To(Equal(ErrorLevel))
-					SetLogLevel(StringToLevel("panic"))
+					SetLogLevel(StringToLevel(panicStr))
 					Expect(logLevel).To(Equal(PanicLevel))
 					// by int
 					for i := 1; i <= 5; i++ {

--- a/logging_test.go
+++ b/logging_test.go
@@ -21,7 +21,6 @@ const (
 	warningMsg = "This is a WARNING message"
 	infoMsg    = "This is an INFO message"
 	debugMsg   = "This is a DEBUG message"
-	verboseMsg = "This is a VERBOSE message"
 )
 
 type customPrefix struct {
@@ -279,8 +278,6 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(logFileContains(logFile, infoMsg)).To(BeFalse())
 				Debugf(debugMsg)
 				Expect(logFileContains(logFile, debugMsg)).To(BeFalse())
-				Verbosef(verboseMsg)
-				Expect(logFileContains(logFile, verboseMsg)).To(BeFalse())
 			})
 
 			It("should print appropriate >= error structured messages to log file", func() {
@@ -298,8 +295,6 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg))).To(BeFalse())
 				DebugStructured(debugMsg)
 				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="debug" msg=%q`, debugMsg))).To(BeFalse())
-				VerboseStructured(verboseMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="verbose" msg=%q`, verboseMsg))).To(BeFalse())
 			})
 		})
 
@@ -319,8 +314,6 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(logFileContains(logFile, infoMsg)).To(BeTrue())
 				Debugf(debugMsg)
 				Expect(logFileContains(logFile, debugMsg)).To(BeFalse())
-				Verbosef(verboseMsg)
-				Expect(logFileContains(logFile, verboseMsg)).To(BeFalse())
 			})
 
 			It("should print appropriate >= info structured messages to log file", func() {
@@ -338,15 +331,13 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg))).To(BeTrue())
 				DebugStructured(debugMsg)
 				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="debug" msg=%q`, debugMsg))).To(BeFalse())
-				VerboseStructured(verboseMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="verbose" msg=%q`, verboseMsg))).To(BeFalse())
 			})
 		})
 
-		When("log level is set to VERBOSE and messages are logged", func() {
-			It("should print appropriate >= verbose messages to log file", func() {
+		When("log level is set to DEBUG and messages are logged", func() {
+			It("should print appropriate >= debug messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("verbose"))
+				SetLogLevel(StringToLevel("debug"))
 				SetLogStderr(false)
 
 				Panicf(panicMsg)
@@ -359,13 +350,11 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(logFileContains(logFile, infoMsg)).To(BeTrue())
 				Debugf(debugMsg)
 				Expect(logFileContains(logFile, debugMsg)).To(BeTrue())
-				Verbosef(verboseMsg)
-				Expect(logFileContains(logFile, verboseMsg)).To(BeTrue())
 			})
 
-			It("should print appropriate >= verbose structured messages to log file", func() {
+			It("should print appropriate >= debug structured messages to log file", func() {
 				SetLogFile(logFile)
-				SetLogLevel(StringToLevel("verbose"))
+				SetLogLevel(StringToLevel("debug"))
 				SetLogStderr(false)
 
 				PanicStructured(panicMsg)
@@ -378,8 +367,6 @@ var _ = Describe("CNI Logging Operations", func() {
 				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="info" msg=%q`, infoMsg))).To(BeTrue())
 				DebugStructured(debugMsg)
 				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="debug" msg=%q`, debugMsg))).To(BeTrue())
-				VerboseStructured(verboseMsg)
-				Expect(logFileContainsRegex(logFile, fmt.Sprintf(`time=".*" level="verbose" msg=%q`, verboseMsg))).To(BeTrue())
 			})
 		})
 
@@ -491,7 +478,7 @@ var _ = Describe("CNI Logging Operations", func() {
 
 		When("a custom prefix is provided", func() {
 			BeforeEach(func() {
-				SetLogLevel(StringToLevel("verbose"))
+				SetLogLevel(StringToLevel("debug"))
 				SetPrefixer(&customPrefix{
 					prefixFormat: "[%s/%s] - %s: ",
 					currentFile:  "logging_test.go",
@@ -499,7 +486,7 @@ var _ = Describe("CNI Logging Operations", func() {
 			})
 
 			It("uses the custom prefix", func() {
-				expectedPrefix := "[info/verbose] - logging_test.go: "
+				expectedPrefix := "[info/debug] - logging_test.go: "
 				errStr := captureStdErrEvent(Infof, infoMsg)
 				Expect(errStr).To(ContainSubstring(expectedPrefix))
 				Expect(logFileContains(logFile, expectedPrefix)).To(BeTrue())
@@ -533,7 +520,7 @@ var _ = Describe("CNI Logging Operations", func() {
 
 		When("a custom structured prefix is provided", func() {
 			BeforeEach(func() {
-				SetLogLevel(StringToLevel("verbose"))
+				SetLogLevel(StringToLevel("debug"))
 				SetStructuredPrefixer(&customPrefix{
 					currentFile: "logging_test.go",
 				})
@@ -586,7 +573,7 @@ var _ = Describe("CNI Log Level Operations", func() {
 				It("returns the correct level value", func() {
 					Expect(StringToLevel("warning")).To(Equal(WarningLevel))
 					Expect(StringToLevel("ERROR")).To(Equal(ErrorLevel))
-					Expect(StringToLevel("vErBoSe")).To(Equal(VerboseLevel))
+					Expect(StringToLevel("dEbUg")).To(Equal(DebugLevel))
 				})
 			})
 
@@ -608,8 +595,6 @@ var _ = Describe("CNI Log Level Operations", func() {
 					Expect(logLevel).To(Equal(DebugLevel))
 					SetLogLevel(StringToLevel("info"))
 					Expect(logLevel).To(Equal(InfoLevel))
-					SetLogLevel(StringToLevel("verbose"))
-					Expect(logLevel).To(Equal(VerboseLevel))
 					SetLogLevel(StringToLevel("warning"))
 					Expect(logLevel).To(Equal(WarningLevel))
 					SetLogLevel(StringToLevel("error"))
@@ -617,14 +602,14 @@ var _ = Describe("CNI Log Level Operations", func() {
 					SetLogLevel(StringToLevel("panic"))
 					Expect(logLevel).To(Equal(PanicLevel))
 					// by int
-					for i := 1; i <= 6; i++ {
+					for i := 1; i <= 5; i++ {
 						l := Level(i)
 						SetLogLevel(l)
 						Expect(logLevel).To(Equal(l))
 					}
 					// by level
-					SetLogLevel(VerboseLevel)
-					Expect(logLevel).To(Equal(VerboseLevel))
+					SetLogLevel(DebugLevel)
+					Expect(logLevel).To(Equal(DebugLevel))
 					SetLogLevel(WarningLevel)
 					Expect(logLevel).To(Equal(WarningLevel))
 				})


### PR DESCRIPTION
Follow the standard established by crio and go with logging levels Panic through Debug. Remove the Verbose logging level.

Return InvalidLevel from StringToLevel instead of -1

Add proper formatting to structuredMessage args

Fixes https://github.com/k8snetworkplumbingwg/cni-log/issues/10